### PR TITLE
Split DB into schemas

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,9 @@ cache:
 
 before_install:
 - psql -c 'CREATE DATABASE nycodex;' -U postgres
+- psql -d nycodex -c 'CREATE SCHEMA IF NOT EXISTS raw;' -U postgres
+- psql -d nycodex -c 'CREATE SCHEMA IF NOT EXISTS api;' -U postgres
+- psql -d nycodex -c 'CREATE SCHEMA IF NOT EXISTS metadata;' -U postgres
 - echo "DATABASE_URI=postgresql://postgresql@localhost/nycodex" > .env
 install:
 - pip install pipenv

--- a/nycodex/db/metadata.py
+++ b/nycodex/db/metadata.py
@@ -70,6 +70,7 @@ class DataType:
 
 class Dataset(Base, DbMixin):
     __tablename__ = "dataset"
+    __table_args__ = {'schema': 'metadata'}
 
     id = sqlalchemy.Column(sqlalchemy.CHAR(9), primary_key=True)
     owner_id = sqlalchemy.Column(sqlalchemy.CHAR(9), nullable=False)

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -3,7 +3,12 @@
 # Setup Postgres
 
 sudo -u postgres createuser --superuser adi
-
 sudo -u postgres createdb -E UTF8 -l en_US.UTF8 -T template0 -O adi nycodex
-sudo -u postgres echo "ALTER ROLE adi WITH PASSWORD 'password'" | sudo -u postgres psql -d nycodex
-sudo -u postgres echo "CREATE EXTENSION postgis;" | sudo -u postgres psql -d nycodex
+
+sudo -u postgres psql -d nycodex <<EOL
+ALTER ROLE adi WITH PASSWORD 'password';
+CREATE EXTENSION IF NOT EXISTS postgis;
+CREATE SCHEMA IF NOT EXISTS raw;
+CREATE SCHEMA IF NOT EXISTS api;
+CREATE SCHEMA IF NOT EXISTS metadata;
+EOL

--- a/scripts/drop.sh
+++ b/scripts/drop.sh
@@ -3,5 +3,11 @@
 sudo -u postgres dropdb nycodex
 
 sudo -u postgres createdb -E UTF8 -l en_US.UTF8 -T template0 -O adi nycodex
-sudo -u postgres echo "ALTER ROLE adi WITH PASSWORD 'password'" | sudo -u postgres psql -d nycodex
-sudo -u postgres echo "CREATE EXTENSION postgis;" | sudo -u postgres psql -d nycodex
+
+sudo -u postgres psql -d nycodex <<EOL
+ALTER ROLE adi WITH PASSWORD 'password';
+CREATE EXTENSION IF NOT EXISTS postgis;
+CREATE SCHEMA IF NOT EXISTS raw;
+CREATE SCHEMA IF NOT EXISTS api;
+CREATE SCHEMA IF NOT EXISTS metadata;
+EOL

--- a/scripts/socrata_metadata.py
+++ b/scripts/socrata_metadata.py
@@ -8,6 +8,7 @@ import requests
 from nycodex import db
 from nycodex.logging import get_logger
 
+
 BASE = "https://api.us.socrata.com/api/catalog/v1"
 DOMAIN = "data.cityofnewyork.us"
 


### PR DESCRIPTION
So SQLAlchemy is a bit prickly when it comes to handling schemas, so using [this workaround](https://bitbucket.org/zzzeek/sqlalchemy/issues/3982/create-and-check-schema-on-orm#comment-40130990) to be able to create schemas. There's probably a couple different ways of doing this, like setting up a trigger outlined [here](http://docs.sqlalchemy.org/en/latest/core/ddl.html#controlling-ddl-sequences), though either one seems fine to me. Alternatively, we would use some sort of migration library like alembic, though that seems like a bit of work if we're just trying to create schemas.